### PR TITLE
Add sd-jwt & hb-jwt to the supported formats 

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/prex/Types.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/prex/Types.kt
@@ -109,6 +109,8 @@ sealed interface ClaimFormat {
         JWT,
         JWT_VC,
         JWT_VP,
+        SD_JWT,
+        HB_JWT,
     }
 
     enum class LdpType : ClaimFormat {

--- a/src/main/kotlin/eu/europa/ec/eudi/prex/internal/Serialization.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/prex/internal/Serialization.kt
@@ -155,6 +155,8 @@ internal object ClaimFormatSerializer : KSerializer<ClaimFormat> {
         "jwt" -> ClaimFormat.JwtType.JWT
         "jwt_vc" -> ClaimFormat.JwtType.JWT_VC
         "jwt_vp" -> ClaimFormat.JwtType.JWT_VP
+        "sd_jwt" -> ClaimFormat.JwtType.SD_JWT
+        "hb_jwt" -> ClaimFormat.JwtType.HB_JWT
         "ldp" -> ClaimFormat.LdpType.LDP
         "ldp_vc" -> ClaimFormat.LdpType.LDP_VC
         "ldp_vp" -> ClaimFormat.LdpType.LDP_VP
@@ -166,6 +168,8 @@ internal object ClaimFormatSerializer : KSerializer<ClaimFormat> {
         ClaimFormat.JwtType.JWT -> "jwt"
         ClaimFormat.JwtType.JWT_VC -> "jwt_vc"
         ClaimFormat.JwtType.JWT_VP -> "jwt_vp"
+        ClaimFormat.JwtType.SD_JWT -> "sd_jwt"
+        ClaimFormat.JwtType.HB_JWT -> "hb_jwt"
         ClaimFormat.LdpType.LDP -> "ldp"
         ClaimFormat.LdpType.LDP_VC -> "ldp_vc"
         ClaimFormat.LdpType.LDP_VP -> "ldp_vp"

--- a/src/test/kotlin/eu/europa/ec/eudi/prex/MatcherSample.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/prex/MatcherSample.kt
@@ -104,8 +104,31 @@ data class SimpleClaim(override val uniqueId: String, override val format: Claim
         override fun asJsonString(): String = value.toString()
     }
 
-fun main() {
+fun basicExample() {
     val presentationDefinition = loadPresentationDefinition("v2.0.0/presentation-definition/basic_example.json")
     val claims = listOf(bankAccount, passport)
     PresentationExchange.matcher.match(presentationDefinition, claims).also { printResult(it) }
+}
+
+val fiId = SimpleClaim(
+    uniqueId = "samplePassport",
+    format = ClaimFormat.JwtType.SD_JWT,
+    value = buildJsonObject {
+        put("iss", "fi.dvv.digiid")
+        putJsonObject("credentialSubject") {
+            put("nationality", "GR")
+            put("gender", 0)
+        }
+    },
+)
+
+fun fiExample() {
+    val presentationDefinition = loadPresentationDefinition("v2.0.0/presentation-definition/fi.json")
+    val claims = listOf(fiId)
+    PresentationExchange.matcher.match(presentationDefinition, claims).also { printResult(it) }
+}
+
+fun main() {
+    basicExample()
+    fiExample()
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/prex/PresentationDefinitionTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/prex/PresentationDefinitionTest.kt
@@ -52,6 +52,13 @@ class PresentationDefinitionTest {
         }
     }
 
+    @Test
+    fun `fi example`() {
+        testParseDefinition("v2.0.0/presentation-definition/fi.json").also {
+            it.submissionRequirements?.forEach { x -> println(x) }
+        }
+    }
+
     private fun testParseDefinition(f: String): PresentationDefinition =
         PresentationExchange.jsonParser.decodePresentationDefinition(load(f)!!)
             .also { println(it) }

--- a/src/test/resources/v2.0.0/presentation-definition/fi.json
+++ b/src/test/resources/v2.0.0/presentation-definition/fi.json
@@ -1,0 +1,69 @@
+{
+  "id": "",
+  "format": {
+    "sd_jwt": {
+      "alg": [
+        "ES384"
+      ]
+    },
+    "hb_jwt": {
+      "alg": [
+        "ES256"
+      ]
+    }
+  },
+  "input_descriptors": [
+    {
+      "id": "nationality",
+      "constraints": {
+        "fields": [
+          {
+            "path": [
+              "$.iss"
+            ],
+            "filter": {
+              "const": "fi.dvv.digiid"
+            }
+          },
+          {
+            "path": [
+              "$.credentialSubject.nationality"
+            ],
+            "filter": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "gender",
+      "constraints": {
+        "fields": [
+          {
+            "path": [
+              "$.iss"
+            ],
+            "filter": {
+              "const": "fi.dvv.digiid"
+            }
+          },
+          {
+            "path": [
+              "$.credentialSubject.gender"
+            ],
+            "filter": {
+              "type": "integer",
+              "enum": [
+                0,
+                1,
+                2,
+                9
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Added to the list of supported formats the option of `sd-jwt` and `hb-jwt`.
This will allow a Verifier to define within a `PresentationDefinition` that requires (from wallet) to reply with a sd-jwt.

An example `PresentationDefinition` was added to the test,s which has been produced by [https://test.id.cloud.dvv.fi](https://test.id.cloud.dvv.fi).