### PR TITLE
Remove hard-coded organization name from sonar cloud github action

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,7 +1,7 @@
 name: SonarCloud
 on:
   push:
-    branches: [ 'main', 'feature/sonar*' ]
+    branches: [ 'main', 'feature/*' ]
     tags: [ v* ]
 
 


### PR DESCRIPTION
Remove hard-coded organization name from sonar cloud github action.
