### PR TITLE
Configure and use com.vanniktech.maven.publish for Maven publications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,13 +45,13 @@ jobs:
       - name: Publish with Gradle Wrapper
         uses: gradle/gradle-build-action@v2.8.1
         with:
-          arguments: publish --full-stacktrace
+          arguments: publishAllPublicationsToMavenCentral --full-stacktrace
         env:
           CI: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.OSSRH_GPG_KEY_ID }}
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.OSSRH_GPG_PASSPHRASE }}
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.OSSRH_USERNAME }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.OSSRH_GPG_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.OSSRH_GPG_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
           GIT_REF_NAME: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,13 +24,13 @@ jobs:
         uses: gradle/gradle-build-action@v2.8.1
         with:
           gradle-version: wrapper
-          arguments: build publish --full-stacktrace
+          arguments: build publishAllPublicationsToMavenCentral --no-configuration-cache --full-stacktrace
         env:
           CI: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.OSSRH_GPG_KEY_ID }}
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.OSSRH_GPG_PASSPHRASE }}
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.OSSRH_USERNAME }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.OSSRH_GPG_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.OSSRH_GPG_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
           GIT_REF_NAME: ${{ github.ref_name }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,14 @@
 import org.jetbrains.dokka.DokkaConfiguration.Visibility
 import org.jetbrains.dokka.gradle.DokkaTask
 import java.net.URL
-import kotlin.jvm.optionals.getOrNull
+
+object Meta {
+    const val BASE_URL = "https://github.com/eu-digital-identity-wallet/eudi-lib-jvm-presentation-exchange-kt"
+}
 
 plugins {
     base
     `java-library`
-    `maven-publish`
-    signing
     jacoco
     alias(libs.plugins.dokka)
     alias(libs.plugins.kotlin.jvm)
@@ -15,9 +16,8 @@ plugins {
     alias(libs.plugins.spotless)
     alias(libs.plugins.sonarqube)
     alias(libs.plugins.dependencycheck)
+    alias(libs.plugins.maven.publish)
 }
-
-extra["isReleaseVersion"] = !version.toString().endsWith("SNAPSHOT")
 
 repositories {
     mavenCentral()
@@ -32,10 +32,10 @@ dependencies {
 }
 
 java {
-    withSourcesJar()
     val javaVersion = libs.versions.java.get()
     sourceCompatibility = JavaVersion.toVersion(javaVersion)
 }
+
 kotlin {
     jvmToolchain {
         val javaVersion = libs.versions.java.get()
@@ -63,15 +63,6 @@ tasks.jar {
 }
 
 //
-// Redefine javadocJar in terms of Dokka
-//
-val javadocJar = tasks.register<Jar>("javadocJar") {
-    dependsOn(tasks.dokkaHtml)
-    from(tasks.dokkaHtml.flatMap { it.outputDirectory })
-    archiveClassifier.set("javadoc")
-}
-
-//
 // Configuration of Dokka engine
 //
 tasks.withType<DokkaTask>().configureEach {
@@ -85,7 +76,7 @@ tasks.withType<DokkaTask>().configureEach {
 
             documentedVisibilities.set(setOf(Visibility.PUBLIC, Visibility.PROTECTED))
 
-            val remoteSourceUrl = System.getenv()["GIT_REF_NAME"]?.let { URL("${Meta.PROJ_BASE_DIR}/tree/$it/src") }
+            val remoteSourceUrl = System.getenv()["GIT_REF_NAME"]?.let { URL("${Meta.BASE_URL}/tree/$it/src") }
             remoteSourceUrl
                 ?.let {
                     sourceLink {
@@ -115,76 +106,11 @@ spotless {
     }
 }
 
-object Meta {
-    const val ORG_URL = "https://github.com/eu-digital-identity-wallet"
-    const val PROJ_DESCR = "Implementation of Presentation Exchange v2"
-    const val PROJ_BASE_DIR = "https://github.com/eu-digital-identity-wallet/eudi-lib-jvm-presentation-exchange-kt"
-    const val PROJ_GIT_URL =
-        "scm:git:git@github.com:eu-digital-identity-wallet/eudi-lib-jvm-presentation-exchange-kt.git"
-    const val PRJ_SSH_URL =
-        "scm:git:ssh://github.com:eu-digital-identity-wallet/eudi-lib-jvm-presentation-exchange-kt.git"
-}
-publishing {
-
-    publications {
-        create<MavenPublication>("library") {
-            from(components["java"])
-            artifacts + artifact(javadocJar)
-            pom {
-                name.set(project.name)
-                description.set(Meta.PROJ_DESCR)
-                url.set(Meta.PROJ_BASE_DIR)
-                licenses {
-                    license {
-                        name.set("The Apache License, Version 2.0")
-                        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-                    }
-                }
-                scm {
-                    connection.set(Meta.PROJ_GIT_URL)
-                    developerConnection.set(Meta.PRJ_SSH_URL)
-                    url.set(Meta.PROJ_BASE_DIR)
-                }
-                issueManagement {
-                    system.set("github")
-                    url.set(Meta.PROJ_BASE_DIR + "/issues")
-                }
-                ciManagement {
-                    system.set("github")
-                    url.set(Meta.PROJ_BASE_DIR + "/actions")
-                }
-                developers {
-                    organization {
-                        url.set(Meta.ORG_URL)
-                    }
-                }
-            }
+mavenPublishing {
+    pom {
+        ciManagement {
+            system = "github"
+            url = "${Meta.BASE_URL}/actions"
         }
     }
-    repositories {
-
-        val sonaUri =
-            if ((extra["isReleaseVersion"]) as Boolean) {
-                "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-            } else {
-                "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-            }
-
-        maven {
-            name = "sonatype"
-            url = uri(sonaUri)
-            credentials(PasswordCredentials::class)
-        }
-    }
-}
-
-signing {
-    setRequired({
-        (project.extra["isReleaseVersion"] as Boolean) && gradle.taskGraph.hasTask("publish")
-    })
-    val signingKeyId: String? by project
-    val signingKey: String? by project
-    val signingPassword: String? by project
-    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
-    sign(publishing.publications["library"])
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,35 @@
 # Gradle options
 org.gradle.jvmargs=-Xmx4g
 org.gradle.parallel=true
+
 # Kotlin configuration
 kotlin.incremental=true
 kotlin.code.style=official
 
-
+# Project properties
 group=eu.europa.ec.eudi
 version=0.1.0-SNAPSHOT
 
 # Sonar
 systemProp.sonar.host.url=https://sonarcloud.io
+
+# Maven publishing properties
+SONATYPE_HOST=S01
+SONATYPE_AUTOMATIC_RELEASE=false
+RELEASE_SIGNING_ENABLED=true
+
+POM_NAME=EUDI Presentation Exchange v2 library
+POM_DESCRIPTION=Implementation of Presentation Exchange v2
+POM_URL=https://github.com/eu-digital-identity-wallet/eudi-lib-jvm-presentation-exchange-kt
+
+POM_LICENSE_NAME=The Apache License, Version 2.0
+POM_LICENSE_URL=https://www.apache.org/licenses/LICENSE-2.0.txt
+
+POM_SCM_URL=https://github.com/eu-digital-identity-wallet/eudi-lib-jvm-presentation-exchange-kt
+POM_SCM_CONNECTION=scm:git:git@github.com:eu-digital-identity-wallet/eudi-lib-jvm-presentation-exchange-kt.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://github.com:eu-digital-identity-wallet/eudi-lib-jvm-presentation-exchange-kt.git
+
+POM_ISSUE_SYSTEM=github
+POM_ISSUE_URL=https://github.com/eu-digital-identity-wallet/eudi-lib-jvm-presentation-exchange-kt/issues
+
+POM_DEVELOPER_URL=https://github.com/eu-digital-identity-wallet

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,14 +12,13 @@ sonarqube = "4.3.1.3277"
 dependencycheck = "8.4.0"
 jsonKotlinSchema = "0.41"
 jsonpathkt="2.0.1"
+mavenPublish="0.25.3"
 
 [libraries]
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 nimbus-jose-jwt = { module = "com.nimbusds:nimbus-jose-jwt", version.ref = "nimbusJoseWwt" }
 json-kotlin-schema = { module = "net.pwall.json:json-kotlin-schema", version.ref = "jsonKotlinSchema" }
 jsonpathkt = { module = "com.nfeld.jsonpathkt:jsonpathkt", version.ref = "jsonpathkt" }
-
-
 
 [plugins]
 foojay-resolver-convention = { id = "org.gradle.toolchains.foojay-resolver-convention", version.ref = "foojay" }
@@ -29,5 +28,4 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-plugin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 dependencycheck = { id = "org.owasp.dependencycheck", version.ref = "dependencycheck" }
 sonarqube = { id = "org.sonarqube", version.ref = "sonarqube" }
-
-
+maven-publish = { id = "com.vanniktech.maven.publish", version.ref="mavenPublish" }


### PR DESCRIPTION
This PR configures `com.vanniktech.maven.publish` for Maven publications, and removes the usage of `maven-publish` and `signing` plugins.

`ci` and `release` Actions have been updated to use this plugin instead.

Unfortunately CI management cannot be configured with properties in `gradle.properties`, thus some manual configuration is required in `build.gradle.kts`.

Closes: eu-digital-identity-wallet/eudi-lib-jvm-presentation-exchange-kt#78